### PR TITLE
Check existence of Google Analytics correctly

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -103,7 +103,7 @@
 		<link href="{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
 
 		<!-- Google Analytics -->
-		{{ if and (not hugo.IsServer) (.Site.GoogleAnalytics) }}
+		{{ if and (not hugo.IsServer) (.Site.Params.GoogleAnalytics.Enable) }}
 			{{ template "_internal/google_analytics.html" . }}
 		{{ end }}
 


### PR DESCRIPTION
The wrong (nonexistent) parameter was being referred to for Google Analytics, leading to failures on sites that do not have/use Google Analytics. The underlying issue hasn't been fixed, but the right GA key is being referred to. In order to work around the issue of failures in case GA is absent, create a key under params called googleAnalytics and within it, the enable key and set it to false.